### PR TITLE
Added default secondary search

### DIFF
--- a/plugins/omar-wfs-plugin/grails-app/services/omar/wfs/WebFeatureService.groovy
+++ b/plugins/omar-wfs-plugin/grails-app/services/omar/wfs/WebFeatureService.groovy
@@ -766,6 +766,12 @@ class WebFeatureService
         case 'sortBy':
           if ( wfsParams[wfsParamName]?.trim() )
           {
+            if (!wfsParams[wfsParamName].contains(',') && !wfsParams[wfsParamName].contains('ingest_date')) {
+              if (wfsParams[wfsParamName] ==~ /.*D(ESC)?/)
+                wfsParams[wfsParamName] += ',ingest_date DESC'
+              else
+                wfsParams[wfsParamName] += ',ingest_date ASC'
+            }
             options['sort'] = wfsParams[wfsParamName].split(',').collect {
                 def x = it.split(/ |\+/) as List
                 if ( x[1] ==~ /.*D(ESC)?/ ) {
@@ -773,6 +779,7 @@ class WebFeatureService
                 } else if (x[1] ==~ /.*A(SC)?/) {
                     x = [x[0], 'ASC'] as List
                 }
+                return x
             } as List
           }
           break


### PR DESCRIPTION
`ingest_date` is the default secondary search parameter.
If `ingest_date` is selected/used in GUI or API, OR if more than one sort params are declared in API, default secondary sort is no longer used.

Otherwise:
if `/.*A(SC)?/` , then `ingest_date ASC` is used as the secondary sort param; 
if `/.*D(ESC)?/` then `ingest_date DESC` is used.